### PR TITLE
Builtin/exit

### DIFF
--- a/.github/workflows/ci-builtin-exit.yaml
+++ b/.github/workflows/ci-builtin-exit.yaml
@@ -1,0 +1,31 @@
+name: Minishell
+
+on:
+  push: 
+   branches: [builtin/exit]
+
+jobs:
+  build:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [macos-latest]
+    name: ${{matrix.os}}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path:  minishell
+
+    - name: Make
+      working-directory: minishell
+      run: make
+
+    - name: Test
+      uses: actions/checkout@v2
+      with:
+        repository: cacharle/minishell_test
+        path: test 
+
+    - name: Run test builtin/exit
+      working-directory: test
+      run: ./run builtin/exit

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -2,6 +2,7 @@
 # define MINISHELL_H
 
 # include <string.h>
+# include <stdint.h>
 # include <errno.h>
 # include <dirent.h>
 # include <sys/stat.h>

--- a/srcs/backslash.c
+++ b/srcs/backslash.c
@@ -5,7 +5,7 @@ static short	check_special_char(char c, short parse_mode)
 	if (parse_mode == 0 && (c == '\'' || c == '\"'))
 		return (1);
 	else if (parse_mode == 1
-			&& (c == ' ' || c == '|' || c == ';' ||
+			&& (c == ' ' || c == '\t' || c == '|' || c == ';' ||
 			c == '$' || c == '\\' || is_alpha(c) ||
 			c == '&'))
 		return (1);

--- a/srcs/ft_exit.c
+++ b/srcs/ft_exit.c
@@ -12,11 +12,20 @@
 
 #include "minishell.h"
 
+static	void	numeric_arg_req(t_shell *shell)
+{
+	char		*msg;
+
+	msg = ft_strjoin(shell->binary, ": ");
+	msg = ft_strjoin(msg, shell->args[1]);
+	print_errors(shell, " numeric argument required", msg);
+	exit (255);
+}
+
 static	int		exit_atoi(t_shell *shell, const char *nptr)
 {
-	long long	num;
-	int		sign;
-	char	*msg;
+	uintmax_t	num;
+	int			sign;
 
 	num = 0;
 	sign = 0;
@@ -33,29 +42,17 @@ static	int		exit_atoi(t_shell *shell, const char *nptr)
 		nptr++;
 	while (*nptr)
 	{
-		if ((!ft_isdigit(*nptr) && *nptr != ' ' && *nptr != '\t') || ft_strlen(nptr) >= 19)
-		{
-			msg = ft_strjoin(shell->binary, ": ");
-			msg = ft_strjoin(msg, shell->args[1]);
-			print_errors(shell, " numeric argument required", msg);
-			exit (255);
-		}
+		if ((!ft_isdigit(*nptr) && *nptr != ' ' && *nptr != '\t')
+		|| ft_strlen(nptr) > 19)
+			numeric_arg_req(shell);
 		if (*nptr >= '0' && *nptr <= '9')
 			num = num * 10 + *nptr - '0';
 		nptr++;
 	}
-
+	if ((!sign && num > INTMAX_MAX) || (sign && num > (uintmax_t)(-INTMAX_MIN)))
+		numeric_arg_req(shell);
 	if (sign == 1)
 		num = -1 * num;
-	/*if ((*nptr >= 'a' && *nptr <= 'z') || (*nptr >= 'A' && *nptr <= 'Z'))
-	{
-		msg = ft_strjoin(shell->binary, ": ");
-		msg = ft_strjoin(msg, shell->args[1]);
-		print_errors(shell, " numeric argument required", msg);
-		return (255);
-	}*/
-	//if (sign == 1)
-	//	num = -1 * num;
 	return ((int)num);
 }
 

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -242,7 +242,7 @@ static char		*inject_spaces(char *line)
 			cont++;
 	}
 	output = calloc(1, ft_strlen(line) + cont + 1);
-	while (*line == ' ' || *line == '\t')
+	while (*line == ' ')
 	{
 		line++;
 	}

--- a/srcs/quotes_utils.c
+++ b/srcs/quotes_utils.c
@@ -33,7 +33,7 @@ short	is_special_char(char c)
 
 short	is_space(char c)
 {
-	if (c == ' ')
+	if (c == ' ' || c == '\t')
 		return (1);
 	return (0);
 }


### PR DESCRIPTION
**Cambios realizados:**

- Se añaden al parser los tabuladores: se consideran dentro de los `quotes` simples los cuales anulan su carácter para dividir una cadena en argumentos. 

- Se añade comparación con los tipos máximos de la libreria `<stdint.h>` `uintmax_t` y `intmasx_t`