### PR TITLE
Fix/preprocess interpolation

### DIFF
--- a/.github/workflows/ci-preprocess-interpolation.yaml
+++ b/.github/workflows/ci-preprocess-interpolation.yaml
@@ -2,7 +2,7 @@ name: Minishell
 
 on:
   push: 
-   branches: [fix/preprocess-interpolation-expansion]
+   branches: [fix/preprocess-interpolation]
 
 jobs:
   build:

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -71,6 +71,7 @@ char	*get_path(t_shell *shell, int *binary);
 
 char	*expansion(t_shell *shell, char *str);
 char	*embrace_expansion(char *str);
+char	*expand_var(char *env, t_shell *shell);
 char    *mantain_expansion_spaces(char *str);
 char	*parse_quotes(char *str);
 char	*parse_backslash(char *str, short residual);

--- a/srcs/expansion.c
+++ b/srcs/expansion.c
@@ -96,18 +96,24 @@ static	char	*get_env_value(t_shell *shell, char *delimiter, int i)
 	return (ret);
 }
 
-static	char	*expand_var(char *env, t_shell *shell)
+char	*expand_var(char *env, t_shell *shell)
 {
 	int		i;
 	int		len;
 	char	*delimiter;
 
 	i = 0;
-	env++;
-	//free(env);
-	//delimiter = search_delimiters(env);
-	delimiter = ft_strchr(env, '}');
-	len = ft_strlen(env) - (delimiter ? ft_strlen(delimiter) : 0);
+	delimiter = NULL;
+	if (*env == '{')
+	{
+		env++;
+		//free(env);
+		//delimiter = search_delimiters(env);
+		delimiter = ft_strchr(env, '}');
+		len = ft_strlen(env) - (delimiter ? ft_strlen(delimiter) : 0);
+	}
+	else
+		len = ft_strlen(env);
 	if (delimiter && *(delimiter - 1) == ' ')
 		len--;
 	while (shell->env[i])

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -401,7 +401,7 @@ int 			main(int argc, char **argv, char **envp)
 	ft_export(&shell, ft_strjoin("PWD=", curr_pwd));
 	shell.instructions = NULL;
 	handle_shlvl(&shell);
-	//ft_export(&shell, ft_strdup("_=/bin/bash"));
+	ft_export(&shell, ft_strdup("_=/bin/bash"));
 	if (argc == 3 && ft_strcmp(argv[1], "-c"))
 	{
 		line = ft_strdup(argv[2]);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -170,6 +170,53 @@ static void 	handle_commands(t_shell *shell)
 	}
 }
 
+static char		*get_var_key(char *line, int it)
+{
+	int		i;
+	int		k;
+	char	*key;
+
+	i = it;
+	k = 0;
+	while (i >= 0 && line[i] != '{')
+		i--;
+	if (!(key = malloc((it - i) * sizeof(char))))
+		return (NULL);
+	i++;
+	while (i < it)
+		key[k++] = line[i++];
+	key[k] = '\0';
+	return (key);
+}
+
+static short	contain_spaces(char *value)
+{
+	while (*value)
+	{
+		if (*value == ' ')
+			return (1);
+		value++;
+	}
+	return (0);
+}
+
+static char 	*post_to_token(t_shell *shell, char *line, int it, char token)
+{
+	char	*key;
+	char	*value;
+
+	if (token == '>')
+		while (line[it++])
+			if (line[it] == '}' && line[it - 1] != ' ')
+			{
+				key = get_var_key(line, it);
+				value = expand_var(key, shell);
+				if (contain_spaces(value))
+					return (ft_strjoin("$", key));
+			}
+	return (NULL);
+}
+
 static short 	prior_to_token(char *line, int it, char token)
 {
 	int aux_it;
@@ -192,6 +239,8 @@ static short 	prior_to_token(char *line, int it, char token)
 
 static void 	validator(t_shell *shell, char *line, char separator, int it)
 {
+	char	*key;
+
 	if (prior_to_token(line, it - 1, line[it]))
 	{
 		if (separator == ';')
@@ -209,6 +258,11 @@ static void 	validator(t_shell *shell, char *line, char separator, int it)
 		exit(2);
 		// Arreglarlo para que no salga de la ejecucion principal
 		//shell->stat_loc = 2;
+	}
+	else if ((key = post_to_token(shell, line, it, line[it])))
+	{
+		print_errors(shell, ft_strjoin(key,": ambiguous redirect" ), NULL);
+		exit(1);
 	}
 }
 

--- a/srcs/quotes_utils.c
+++ b/srcs/quotes_utils.c
@@ -26,7 +26,7 @@ short	is_alpha(char c)
 
 short	is_special_char(char c)
 {
-	if (c == '$' || c == '\\' || c == '|' || c == ';')
+	if (c == '$' || c == '\\' || c == '|' || c == ';' || c == '\'')
 		return (1);
 	return (0);
 }


### PR DESCRIPTION
### Cambios

**Fix 1**: se trata el error especial `ambiguos redirect` que aparece cuando se expande una variable que contiene espacios y no se encuentra entre quotes dobles

**Fix 2**: se arregla `SIGABORT` al destapar la asignación de `/bin/bash`. El error viene originado al no asignarse el tamaño correcto para la cadena de tipo especial compuesta exclusivamente por `'` dentro de la función `get_string_between_quotes` mediante la función que cuenta los caracteres especiales a escapar `n_special_chars`. Ello causa un overflow que se destapa al descomentar la asignación `$_=/bin/bash` lo cual, entiendo que, repercute al añadir una cadena más al heap, las cuales probablemente sean consecutivas o cercanas, pisando de esta forma memoria prohibida.